### PR TITLE
Minimize Slot Data Use

### DIFF
--- a/YARG/world.py
+++ b/YARG/world.py
@@ -438,14 +438,12 @@ class YARG(World):
             metadatalist = []
             songid = str((Songs.get(name)).songname)
             loc1id = LOCATION_NAME_TO_ID["\"" + itemnamefromindex(name) + "\" Item 1"]
-            itemid = ITEM_NAME_TO_ID[itemnamefromindex(name)]
             source = str((Songs.get(name)).source)
             artist = (Songs.get(name)).artistname
             if self.shuffletoggle:
                 instru = str(self.songinstruments[name])
             metadatalist.append(songid)
             metadatalist.append(loc1id)
-            metadatalist.append(itemid)
             metadatalist.append(source)
             metadatalist.append(artist)
             if self.shuffletoggle:

--- a/YARG/world.py
+++ b/YARG/world.py
@@ -438,8 +438,6 @@ class YARG(World):
             metadatalist = []
             songid = str((Songs.get(name)).songname)
             loc1id = LOCATION_NAME_TO_ID["\"" + itemnamefromindex(name) + "\" Item 1"]
-            loc2id = LOCATION_NAME_TO_ID["\"" + itemnamefromindex(name) + "\" Item 2"]
-            loc3id = LOCATION_NAME_TO_ID["\"" + itemnamefromindex(name) + "\" Item 3"]
             itemid = ITEM_NAME_TO_ID[itemnamefromindex(name)]
             source = str((Songs.get(name)).source)
             artist = (Songs.get(name)).artistname
@@ -447,8 +445,6 @@ class YARG(World):
                 instru = str(self.songinstruments[name])
             metadatalist.append(songid)
             metadatalist.append(loc1id)
-            metadatalist.append(loc2id)
-            metadatalist.append(loc3id)
             metadatalist.append(itemid)
             metadatalist.append(source)
             metadatalist.append(artist)


### PR DESCRIPTION
This minimizes the amount of content kept in slot data by removing the 2 extra location IDs and the Item ID from slot data. The client now calculates these IDs based on the single location ID.

This is step one in lowering the amount of slot data that YARG uses.